### PR TITLE
feat: remove nvim-treesitter dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Neovim plugin for treesitter based navigation and selection.
 Takes inspiration from [ParEdit](https://calva.io/paredit/).
 
+Requires neovim >= 0.10.
+
 ## Usage
 
 ### Navigation
@@ -61,11 +63,6 @@ require('nvim-treeclimber').setup()
 
 If you want to change the default keybindings, call `require('nvim-treeclimber')` rather than calling setup.
 See [configuration](#configuration).
-
-## Dependencies
-
-**Required**
-- [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
 
 ## Configuration
 

--- a/lua/nvim-treeclimber/api.lua
+++ b/lua/nvim-treeclimber/api.lua
@@ -76,7 +76,7 @@ local top_level_types = {
 ---@param bufnr number | nil
 ---@param lang string | nil
 local function get_parser(bufnr, lang)
-	return require("nvim-treesitter.parsers").get_parser(bufnr, lang)
+	return vim.treesitter.get_parser(bufnr, lang)
 end
 
 ---Returns the root node of the tree from the current parser


### PR DESCRIPTION
`nvim-treesitter` is deprecating their plugin APIs
another example of a plugin migrating: https://github.com/windwp/nvim-autopairs/pull/448
more info: https://github.com/nvim-treesitter/nvim-treesitter/issues/4767