### PR TITLE
fix: handle case where bg is nil

### DIFF
--- a/lua/nvim-treeclimber.lua
+++ b/lua/nvim-treeclimber.lua
@@ -13,7 +13,8 @@ function M.setup(_)
 		local term_colors = hi.ansi_colors()
 		local hi_normal = hi.get_hl("Normal", { follow = true })
 
-		hi_normal = hi_normal and hi.HSLUVHighlight:new(hi_normal) or { bg = term_colors[0], fg = term_colors[1] }
+		hi_normal = hi_normal and hi_normal.bg and hi.HSLUVHighlight:new(hi_normal)
+			or { bg = term_colors[0], fg = term_colors[1] }
 
 		if vim.tbl_isempty(hi_normal) then
 			return

--- a/lua/nvim-treeclimber/api.lua
+++ b/lua/nvim-treeclimber/api.lua
@@ -1,7 +1,6 @@
 local ts = vim.treesitter
 local f = vim.fn
 local a = vim.api
-local uv = vim.loop
 local logger = require("nvim-treeclimber.logger").new("Treeclimber log")
 local pos = require("nvim-treeclimber.data.pos")
 local pos_range = require("nvim-treeclimber.data.pos_range")


### PR DESCRIPTION
closes https://github.com/Dkendal/nvim-treeclimber/issues/6
I am not sure how to best handle this case, but I think that if the `bg` is transparent, this might be the cleanest approach to get some highlights defined and not error out