### PR TITLE
fix: handle visualmode V and CTRL-V

### DIFF
--- a/lua/nvim-treeclimber/api.lua
+++ b/lua/nvim-treeclimber/api.lua
@@ -263,6 +263,8 @@ end
 local function resume_visual_charwise()
 	if f.visualmode() == "v" then
 		vim.cmd.normal("gv")
+	elseif f.visualmode() == "V" or f.visualmode() == "<CTRL-V>" then
+		vim.cmd.normal("gvv")
 	else
 		vim.cmd.normal("gvgh")
 	end


### PR DESCRIPTION
fixes #7 
I finally took a dive into this issue
So the problem was that, under line-wise visual or block-wise visual modes, `gh` would enter `SELECT` mode, while under character-wise visual mode, it enters `NORMAL` mode. I couldn't find any docs referencing this last behavior of vim (v_gh enters normal mode), but anyone can confirm this.
When triggering any further treeclimber functions inside select mode, the issue is reproduced. For example, if you have:

```
vim.keymap.set({ "n", "x", "o" }, "<M-k>", tc.select_expand, { desc = "select parent node" })
```

And you enter select mode (via `gh` for example), and then press `<M-k>`, the selected character will be replaced by `gk`. I can't really explain why this happens, but it's obvious that we need to avoid select mode when using `treeclimber` operations.
This PR will avoid select mode for all values of `vim.fn.visualmode` 🙂

PS: would be cool to be able to explain why SELECT mode ends up behaving this way 