### PR TITLE
Add a configuration mechanism and use it to support user customization of keymaps, user commands and region decorations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Requires neovim >= 0.10.
 
 ### Navigation
 
+The following table lists the treeclimber navigation commands, along with their default keybindings.
+See [Configuration](#configuration) for details on changing the defaults.
+
 | Key binding   | Action                                                                                                                                                                            | Demo                                                                                                                          |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | `alt-h`       | Select the previous sibling node.                                                                                                                                                 | ![select-prev](https://user-images.githubusercontent.com/3162299/203088192-5c3a7f49-aa8f-4927-b9f2-1dc9c5245364.gif)          |
@@ -46,7 +49,23 @@ https://user-images.githubusercontent.com/3162299/203097777-a9a84c2d-8dec-4db8-a
 
 ## Installation
 
-Use your preferred package manager, or the built-in package system (`:help packages`).
+User your preferred package manager, or the built-in package system (`:help packages`).
+
+### [lazy.nvim](https://github.com/folke/lazy.nvim)
+
+```lua
+{
+  "dkendal/nvim-treeclimber",
+  opts = {
+    -- Provide your desired configuration here, or leave empty to use defaults.
+    -- See Configuration section for details...
+  },
+}
+```
+
+### Manual installation
+
+#### Installation via Bash command-line
 
 ```sh
 mkdir -p ~/.config/nvim/pack/dkendal/opt
@@ -54,36 +73,166 @@ cd ~/.config/nvim/pack/dkendal/opt
 git clone https://github.com/dkendal/nvim-treeclimber.git
 ```
 
+#### Loading via Neovim package system
+
 ```lua
 -- ~/.config/nvim/init.lua
 vim.cmd.packadd('nvim-treeclimber')
-
-require('nvim-treeclimber').setup()
+require('nvim-treeclimber').setup({ --[[ your config here ]] })
 ```
 
-If you want to change the default keybindings, call `require('nvim-treeclimber')` rather than calling setup.
-See [configuration](#configuration).
+**Note:** If you call the `setup()` function without arguments, treeclimber uses the defaults documented in the following section.
 
 ## Configuration
 
-**To use default highlight, keymaps, and commands call `require('nvim-treeclimber').setup()`.**
+To override specific elements of the default configuration, provide a sparse option table containing only the keys you wish to change.
+The default option table is provided below, with comments documenting the meanings of the various keys.
+Any table you provide to `setup()` will be merged into this one, with preference given to your override.
+If your override has an invalid format, treeclimber will generally emit a warning and fall back to the default setting.
 
-To manually specify the configuration options, take a look at the contents of `lua/nvim-treeclimber.lua` and import or modify the portions that you need.
-
-For example, if you just want the built in user commands and highlights but you want your own keybindings, you can do the following:
+### Default Option Table
 
 ```lua
+{
+  ui = {
+    -- ** Keymaps **
+    -- Each entry of the 'keys' table configures the keymap for a single treeclimber function.
+    -- Note: The `keys` key itself can be set to a boolean to enable defaults or disable keymaps
+    -- altogether.
+    ---@alias modestr "n"|"v"|"x"|"o"|"s"|"i"|"!"|""
+    ---@alias lhs string                # Used as <lhs> in call to `vim.keymap.set`
+    ---@alias KeymapSingle
+    ---| [(modestr|modestr[]), lhs]     # override the default <lhs> and/or modes
+    ---@alias KeymapEntry
+    ---| boolean                        # true to accept default, false to disable
+    ---| nil                            # accept default (same as omitting the command name from table)
+    ---| lhs                            # override the default <lhs> in default mode(s)
+    ---| KeymapSingle                   # override the default <lhs> and/or modes
+    ---| KeymapSingle[]                 # idem, but allows multiple, mode-specific <lhs>'s
+    ---@type table<string, KeymapEntry>
+    keys = {
+      show_control_flow = { "n", "<leader>k"},
+      select_current_node = {
+          {"n", "<M-k>"},
+          {{ "x", "o" }, "i."}
+      },
+      select_first_sibling = {{ "n", "x", "o" }, "<M-[>"},
+      select_last_sibling = {{ "n", "x", "o" }, "<M-]>"},
+      select_top_level = {{ "n", "x", "o" }, "<M-g>"},
+      select_forward = {{ "n", "x", "o" }, "<M-l>"},
+      select_backward = {{ "n", "x", "o" }, "<M-h>"},
+      select_forward_end = {{ "n", "x", "o" }, "<M-e>"},
+      select_grow_forward = {{ "n", "x", "o" }, "<M-L>"},
+      select_grow_backward = {{ "n", "x", "o" }, "<M-H>"},
+      select_expand = {
+        {{"x", "o"}, "a."},
+        {{"x", "o"}, "<M-k>"}
+      },
+      select_shrink = {{ "n", "x", "o" }, "<M-j>"},
+    },
 
-local tc = require('nvim-treeclimber')
+    -- ** User commands **
+    -- Each entry of the 'cmds table configures the user command for a single treeclimber function.
+    -- Note: The 'cmds' key itself can be set to a boolean to enable the defaults or disable user
+    -- commands altogether.
+    ---@alias UserCommandEntry
+    ---| string  # desired name of the user command for this function
+    ---| boolean # true to create the command with the default name, false to disable
+    ---@type {[string]: UserCommandEntry}|boolean
+    cmds = {
+      diff_this = "TCDiffThis",
+      highlight_external_definitions = "TCHighlightExternalDefinitions",
+      show_control_flow = "TCShowControlFlow",
+    },
+  },
 
-tc.setup_augroups()
-tc.setup_user_commands()
+  -- ** Display **
+  display = {
+    regions = {
+      -- Each entry in the table below defines the highlighting applied to one of several regions
+      -- relative to the current selection and its siblings/parent. To override the highlighting
+      -- for a specific region, set the corresponding key to either a `vim.api.keyset.highlight` or
+      -- a callback function that returns one. The callback will be invoked upon colorscheme load
+      -- with an `HSLUVHighlights` object that may be used to "mix" new colors from the currently
+      -- active normal and visual mode fg/bg colors.
+      -- Important Note: The `HSLUV` class provides many color-manipulation methods in addition to
+      -- the `mix()` method used in the defaults. The class's type annotation is provided in the
+      -- next section. Additional detail may be found in "vivid/hsl_like.lua" in the treeclimber
+      -- source.
+      -- Note: The `vim.api.keyset.highlight` can be used to specify more than just fg/bg colors:
+      -- e.g., the following override would make the currently selected region bold and its siblings
+      -- italic:
+      --   highlights = {
+      --     Selection = {bold = true},
+      --     Sibling = {italic = true)
+      --   }
+      -- Note: You can also disable unwanted regions by setting the corresponding key(s) `false`.
+      -- E.g., to disable all but the primary selection region (Selection)...
+      --   highlights = {
+      --     SiblingStart = false, Sibling = false, Parent = false, ParentStart = false
+      --   }
+      ---@alias HSLUVHighlight {bg: HSLUV?, fg: HSLUV?, ctermbg: HSLUV?, ctermfg: HSLUV?}
+      ---@alias HSLUVHighlights {normal: HSLUVHighlight, visual: HSLUVHighlight}
+      ---@alias HighlightCallback fun(o: HSLUVHighlights) : vim.api.keyset.highlight
+      ---@alias HighlightEntry
+      ---| vim.api.keyset.highlight   # passed to `nvim_set_hl()`
+      ---| HighlightCallback          # must return a `vim.api.keyset.highlight`
+      ---| boolean                    # true for default highlighting, false to disable the group
+      ---| nil                        # default highlighting
+      ---@type table<string, HighlightEntry>
+      highlights = {
+        Selection = function(o) return { bold = true, bg = o.visual.bg.hex } end,
+        SiblingStart = false,
+        Sibling = function(o) return { bg = o.visual.bg.mix(o.normal.bg, 50).hex } end,
+        -- Make Parent bg color noticeably lighter than Siblings.
+        Parent = function(o) return { bg = o.visual.bg.mix(o.normal.bg, 80).hex } end,
+        ParentStart = false,
+      },
+      -- `true` to cause attributes like bold and italic to "bleed through" from Parent
+      -- to Siblings.
+      inherit_attrs = true,
+      -- `true` to replace default 'highlights' with user overrides, false or nil to merge
+      replace_defaults = false,
+    },
+  },
+}
+```
 
--- Copied from setup_keymaps
-vim.keymap.set("n", "<leader>k", tc.show_control_flow, {})
-vim.keymap.set({ "x", "o" }, "i.", tc.select_current_node, { desc = "select current node" })
-vim.keymap.set({ "x", "o" }, "a.", tc.select_expand, { desc = "select parent node" })
-...
+### HSLUV Color Support
+
+As mentioned in the default option comments, an object of type `HSLUV` is made available to the `highlights` option callback functions.
+This object facilitates working with *HSL* colors in the more human-friendly *HSLUV* color space.
+Its methods and fields are shown here. For further details, look in the treeclimber source (vivid/hsl_like.lua).
+
+```lua
+---@class HSLUV
+---@field hex string
+---@field h number
+---@field s number
+---@field l number
+---@field rotate fun(n: number): HSLUV
+---@field ro fun(n: number): HSLUV
+---@field saturate fun(n: number): HSLUV
+---@field sa fun(n: number): HSLUV
+---@field abs_saturate fun(n: number): HSLUV
+---@field abs_sa fun(n: number): HSLUV
+---@field desaturate fun(n: number): HSLUV
+---@field de fun(n: number): HSLUV
+---@field abs_desaturate fun(n: number): HSLUV
+---@field abs_de fun(n: number): HSLUV
+---@field lighten fun(n: number): HSLUV
+---@field li fun(n: number): HSLUV
+---@field abs_lighten fun(n: number): HSLUV
+---@field abs_li fun(n: number): HSLUV
+---@field darken fun(n: number): HSLUV
+---@field da fun(n: number): HSLUV
+---@field abs_darken fun(n: number): HSLUV
+---@field abs_da fun(n: number): HSLUV
+---@field mix fun(color: HSLUV, n: number): HSLUV
+---@field readable fun(): HSLUV
+---@field hue fun(n: number): HSLUV
+---@field saturation fun(n: number): HSLUV
+---@field lightness fun(n: number): HSLUV
 ```
 
 ---

--- a/lua/nvim-treeclimber.lua
+++ b/lua/nvim-treeclimber.lua
@@ -1,90 +1,322 @@
 local M = {}
-
 local tc = require("nvim-treeclimber.api")
+local Config = require('nvim-treeclimber.config')
+local Util = require('nvim-treeclimber.util')
+local Hi = require("nvim-treeclimber.hi")
 
 -- Re-export nvim-treeclimber.api
 for k, v in pairs(tc) do
 	M[k] = v
 end
 
+-- Define some aliases for functions whose names don't match their behavior.
+-- Rationale: The descriptions in the README say "select first/last sibling"; however, for
+-- backwards-compatibility reasons, we still need to support the old names.
+-- Design Decision: Not necessary to support the old names as keys in the new option table, since
+-- users who create an option table will see only the new names in the documentation.
+M.select_siblings_backward = M.select_first_sibling
+M.select_siblings_forward = M.select_last_sibling
+
+-- Keymap descriptions (used in call to vim.keymap.set)
+local default_keymap_descriptions = {
+	show_control_flow = "",
+	select_current_node = "Treeclimber select current node",
+	select_forward_end = "Treeclimber select and move to the end of the node, or the end of the next node",
+	select_first_sibling = "Treeclimber select first sibling node",
+	select_last_sibling = "Treeclimber select last sibling node",
+	select_top_level = "Treeclimber select the top level node from the current position",
+	select_backward = "Treeclimber select previous node",
+	select_shrink = "Treeclimber select child node",
+	select_expand = "Treeclimber select parent node",
+	select_forward = "Treeclimber select the next node",
+	select_grow_forward = "Treeclimber add the next node to the selection",
+	select_grow_backward = "Treeclimber add the next node to the selection",
+}
+
+-- User command descriptions (used in call to nvim_create_user_command)
+local default_command_descriptions = {
+	diff_this = "Diff two visual selections based on their AST difference.",
+	highlight_external_definitions = "WIP",
+	show_control_flow = "Populate the quick fix with all branches required to reach the current node.",
+}
+
+-- Validate the input KeymapEntry and return one of the following as the first return value:
+--   * a KeymapEntryCanon to use with vim.keymap.set(), taking defaults into account if applicable
+--   * false if the keymap should be disabled
+--   * nil if the entry is invalid.
+---@param ut treeclimber.KeymapEntry|nil The user entry to validate (or nil to use default)
+---@param dt treeclimber.KeymapEntryCanon The corresponding entry from defaults in canonical form
+---@return treeclimber.KeymapEntryCanon|nil # Keymap entry suitable for use with vim.keymap.set() 
+---                                         # false if disabled
+---                                         # nil on error
+---@return string|nil                       # error msg if first return value is nil
+local function parse_keymap_entry(ut, dt)
+	if ut == nil then
+		-- Note: This is not considered error, so return default (possibly false).
+		return dt
+	end
+	local utyp = type(ut)
+	if utyp == "boolean" or utyp == "string" then
+		if dt == false then
+			return nil, "No default keymap defined for this function and user override incomplete"
+		end
+		if utyp == "boolean" then
+			-- Note: Explicit false disables the map without error or warning.
+			return ut and dt or false
+		elseif utyp == "string" then
+			-- Use default entry with overridden lhs.
+			-- TODO: Warn if there really are multiple mode entries?
+			return vim.iter(dt):map(function (x) return {x[1], ut} end):totable()
+		end
+	end
+	-- At this point, the only valid possibility is a user-supplied table that can be converted
+	-- to canonical form.
+	if Config.is_keymap_single(ut) then
+		-- Return canonical form.
+		return {ut}
+	elseif Config.is_keymap_entry_array(ut) then
+		return ut
+	end
+	-- Invalid format!
+	return nil
+end
+
 function M.setup_keymaps()
-	vim.keymap.set("n", "<leader>k", tc.show_control_flow, {})
-
-	vim.keymap.set({ "x", "o" }, "i.", tc.select_current_node, { desc = "select current node" })
-
-	vim.keymap.set({ "x", "o" }, "a.", tc.select_expand, { desc = "select parent node" })
-
-	vim.keymap.set(
-		{ "n", "x", "o" },
-		"<M-e>",
-		tc.select_forward_end,
-		{ desc = "select and move to the end of the node, or the end of the next node" }
-	)
-
-	vim.keymap.set(
-		{ "n", "x", "o" },
-		"<M-b>",
-		tc.select_backward,
-		{ desc = "select and move to the begining of the node, or the beginning of the next node" }
-	)
-
-	vim.keymap.set({ "n", "x", "o" }, "<M-[>", tc.select_siblings_backward, {})
-
-	vim.keymap.set({ "n", "x", "o" }, "<M-]>", tc.select_siblings_forward, {})
-
-	vim.keymap.set(
-		{ "n", "x", "o" },
-		"<M-g>",
-		tc.select_top_level,
-		{ desc = "select the top level node from the current position" }
-	)
-
-	vim.keymap.set({ "n", "x", "o" }, "<M-h>", tc.select_backward, { desc = "select previous node" })
-
-	vim.keymap.set({ "n", "x", "o" }, "<M-j>", tc.select_shrink, { desc = "select child node" })
-
-	vim.keymap.set({ "n", "x", "o" }, "<M-k>", tc.select_expand, { desc = "select parent node" })
-
-	vim.keymap.set({ "n", "x", "o" }, "<M-l>", tc.select_forward, { desc = "select the next node" })
-
-	vim.keymap.set({ "n", "x", "o" }, "<M-L>", tc.select_grow_forward, { desc = "Add the next node to the selection" })
-
-	vim.keymap.set({ "n", "x", "o" }, "<M-H>", tc.select_grow_backward, { desc = "Add the next node to the selection" })
+	---@type table<string, treeclimber.KeymapEntry>|boolean
+	local ukeys = Config:get("ui.keys")
+	---@type table<string, treeclimber.KeymapEntryCanon> # Default keys
+	local dkeys = Config:get_default("ui.keys")
+	-- User can set entire keys option to boolean to enable/disable *all* default maps.
+	if type(ukeys) == "boolean" then
+		if not ukeys then
+			-- User has disabled keymaps! Nothing do do...
+			return
+		end
+		-- User has requested defaults, either explicitly or with empty table.
+		ukeys = dkeys
+	elseif type(ukeys) == "table" then
+		-- Make sure it's the right kind of table.
+		if vim.isarray(ukeys) and not vim.tbl_isempty(ukeys) then
+			Util.error("Ignoring invalid 'keys' option: %s", vim.inspect(ukeys))
+			ukeys = dkeys
+		else
+			local unk_keys = vim.iter(vim.tbl_keys(ukeys))
+				:filter(function(x) return dkeys[x] == nil end)
+				:join(", ")
+			if #unk_keys > 0 then
+				-- Design Decision: Fall through to use any valid keys.
+				Util.error("Ignoring the following invalid keys in the 'keys' option: %s", unk_keys)
+			end
+		end
+	end
+	-- Loop over default keymap entries.
+	for k, dv in pairs(dkeys) do
+		---@type treeclimber.KeymapEntryCanon
+		local cfg
+		-- Canonicalize default entry.
+		if Config.is_keymap_single(dv) then
+			---@cast dv treeclimber.KeymapSingle
+			dv = {dv}
+		elseif type(dv) == 'table' then
+			-- Make sure it's in canonical form.
+			assert(vim.islist(dv) and
+				vim.iter(dv):all(function (x) return Config.is_keymap_single(x) end),
+				string.format("Internal error: invalid entry in default `keys':"
+				.. " %s => %s", k, vim.inspect(dv)))
+		end
+		if ukeys == dkeys then
+			-- No need to validate default entry
+			---@cast dv treeclimber.KeymapEntryCanon
+			cfg = dv
+		else
+			local uv = ukeys[k]
+			-- Get valid KeymapEntryCanon for the current keymap.
+			---@type treeclimber.KeymapEntryCanon|nil|false
+			local cfg_, err = parse_keymap_entry(uv, dv)
+			if cfg_ == nil then
+				Util.error("Ignoring invalid keymap entry for %s: %s%s",
+					k, vim.inspect(uv), err and " due to error `" .. err .. "'" or "")
+				---@cast dv treeclimber.KeymapEntryCanon
+				cfg = dv
+			else
+				-- Use value returned by parse_keymap_entry (possibly false).
+				---@cast cfg_ treeclimber.KeymapEntryCanon|false
+				cfg = cfg_
+			end
+		end
+		assert(cfg == false or cfg, "Internal error: No fallback keymap entry for " .. k)
+		-- One or more keymaps (corresponding to different mode sets) need to be created for
+		-- the current command.
+		if cfg and type(cfg) == "table" then
+			-- Loop over the mode sets.
+			for _, c in ipairs(cfg) do
+				vim.keymap.set(c[1], c[2], tc[k], { desc = default_keymap_descriptions[k] })
+			end
+		end
+	end
 end
 
 function M.setup_user_commands()
-	vim.api.nvim_create_user_command("TCDiffThis", tc.diff_this, { force = true, range = true, desc = "" })
+	---@type table<string, treeclimber.UserCommandEntry>
+	local ucmds = Config:get("ui.cmds")
+	---@type table<string, treeclimber.UserCommandEntryCanon> # Default keys
+	local dcmds = Config:get_default("ui.cmds")
+	-- User can set entire cmds option to boolean to enable/disable *all* default user commands.
+	if type(ucmds) == "boolean" then
+		if not ucmds then
+			-- User has disabled keymaps! Nothing do do...
+			return
+		end
+		-- User has requested defaults.
+		ucmds = dcmds
+	elseif type(ucmds) == "table" then
+		-- Make sure it's the right kind of table.
+		if vim.isarray(ucmds) and not vim.tbl_isempty(ucmds) then
+			Util.error("Ignoring invalid 'cmds' option: %s", vim.inspect(ucmds))
+			ucmds = dcmds
+		else
+			-- Make sure all keys are valid.
+			local unk_cmds = vim.iter(vim.tbl_keys(ucmds))
+				:filter(function(x) return dcmds[x] == nil end)
+				:join(", ")
+			if #unk_cmds > 0 then
+				-- Design Decision: Fall through to use any valid keys.
+				Util.error("Ignoring the following invalid keys in the 'cmds' option: %s", unk_cmds)
+			end
+		end
+	else
+		Util.error("Ignoring invalid 'cmds' option: %s", vim.inspect(ucmds))
+		ucmds = dcmds
+	end
 
-	vim.api.nvim_create_user_command(
-		"TCHighlightExternalDefinitions",
-		tc.highlight_external_definitions,
-		{ force = true, range = true, desc = "WIP" }
-	)
+	-- Loop over default user command entries.
+	for k, dv in pairs(dcmds) do
+		---@type treeclimber.UserCommandEntryCanon
+		local cfg
+		assert(type(dv) == 'string' or dv == false,
+			string.format("Internal error: Invalid default user command entry for %s: %s",
+			k, vim.inspect(dv)))
+		-- Note: If using all defaults, ucmds may refer to dcmds at this point.
+		local uv = ucmds[k]
+		if type(uv) ~= 'boolean' and type(uv) ~= 'string' and uv ~= nil then
+			-- Type of user entry is invalid.
+			Util.error("Ignoring invalid user command entry for %s: %s",
+				k, vim.inspect(uv))
+			cfg = dv
+		else
+			-- Overall form of user entry appears valid.
+			if type(uv) == 'string' then
+				if string.match(uv, [[^%u[%w_]+$]]) then
+					cfg = uv
+				else
+					Util.error("Ignoring invalid user command name: %s", uv)
+					cfg = dv
+				end
+			elseif uv == true or uv == nil then
+				-- Accept default.
+				cfg = dv
+			else
+				cfg = false -- disable
+			end
+		end
 
-	vim.api.nvim_create_user_command("TCShowControlFlow", tc.show_control_flow, {
-		force = true,
-		range = true,
-		desc = "Populate the quick fix with all branches required to reach the current node",
-	})
+		-- Note: This test (as opposed to simpler `if cfg') is necessitated by what appears
+		-- to be a LuaLS bug: type system should see that cfg can't be true, but thinks it
+		-- can be.
+		if type(cfg) == 'string' then
+			-- Create user command.
+			vim.api.nvim_create_user_command(cfg, tc[k], {
+				force = true, range = true, desc = default_command_descriptions[k]
+			})
+		end
+	end
+end
+
+---@param uhl treeclimber.HighlightEntry
+---@param dhl treeclimber.HighlightEntryDefCanon
+---@param normal HSLUVHighlight
+---@param visual HSLUVHighlight
+---@param replace_defaults boolean Whether default hl is replaced by or merged with user override
+---@return treeclimber.HighlightEntryCanon? cfg Valid hl or false to disable or nil on error
+---@return treeclimber.HighlightEntryCanon? fallback The fallback hl to use on error
+---@return string|nil err An error message in case of fallback
+local function parse_highlight_entry(uhl, dhl, normal, visual, replace_defaults)
+	if type(dhl) == "function" then
+		---@cast dhl vim.api.keyset.highlight
+		dhl = dhl({normal = normal, visual = visual})
+	end
+	if uhl == true or uhl == nil then
+		return dhl -- use default
+	elseif uhl == false then
+		-- Disable this one.
+		return false
+	end
+	-- User provided some sort of override requiring validation (possibly after expansion).
+	if type(uhl) == "function" then
+		uhl = uhl({normal = normal, visual = visual})
+	end
+	-- Validate the user highlight entry by using in protected call to nvim_set_hl().
+	local validation_ns = vim.api.nvim_create_namespace("treeclimber.validation")
+	local valid, _ = pcall(vim.api.nvim_set_hl, validation_ns, "ValidationGroup", uhl)
+	if not valid then
+		return nil, dhl, string.format("Invalid user highlight entry: %s", vim.inspect(uhl))
+	end
+	-- Now that we know user config is valid, merge it with default unless default is `false` or
+	-- the 'replace_defaults' option is set, in which case, we use user highlight as is.
+	-- Note: A default of false is functionally equivalent to {}; default should never be `true`.
+	assert(dhl == false or type(dhl) == 'table', "Internal error: Invalid default highlight: %s", vim.inspect(dhl))
+	return type(dhl) == 'table' and not replace_defaults
+		and vim.tbl_deep_extend('force', dhl, uhl) or uhl
 end
 
 function M.setup_highlight()
 	-- Must run after colorscheme or TermOpen to ensure that terminal_colors are available
-	local hi = require("nvim-treeclimber.hi")
 
-	local Normal = hi.get_hl("Normal", { follow = true })
+	local Normal = Hi.get_hl("Normal", { follow = true })
 	assert(not vim.tbl_isempty(Normal), "hi Normal not found")
-	local normal = hi.HSLUVHighlight:new(Normal)
+	local normal = Hi.HSLUVHighlight:new(Normal)
 
-	local Visual = hi.get_hl("Visual", { follow = true })
+	local Visual = Hi.get_hl("Visual", { follow = true })
 	assert(not vim.tbl_isempty(Visual), "hi Visual not found")
-	local visual = hi.HSLUVHighlight:new(Visual)
+	local visual = Hi.HSLUVHighlight:new(Visual)
 
-	vim.api.nvim_set_hl(0, "TreeClimberHighlight", { background = visual.bg.hex })
-	vim.api.nvim_set_hl(0, "TreeClimberSiblingBoundary", { background = visual.bg.mix(normal.bg, 50).hex })
-	vim.api.nvim_set_hl(0, "TreeClimberSibling", { background = visual.bg.mix(normal.bg, 50).hex })
-	vim.api.nvim_set_hl(0, "TreeClimberParent", { background = visual.bg.mix(normal.bg, 50).hex })
-	vim.api.nvim_set_hl(0, "TreeClimberParentStart", { background = visual.bg.mix(normal.bg, 50).hex })
+	local defaults = Config:get_default("display.regions.highlights")
+	-- Get user overrides.
+	local overrides = Config:get("display.regions.highlights")
+	-- Determine whether default highlights are replace by or merged with user overrides.
+	local replace_defaults = Config:get("display.regions.replace_defaults")
+	-- Skip if entire "highlights" key is explicit false.
+	if type(overrides) ~= "boolean" or overrides then
+		if overrides ~= nil and (type(overrides) ~= "table" or vim.islist(overrides)) then
+			-- Overall form of display.regions.highlight is invalid.
+			Util.error("Ignoring invalid 'highlights' option: expected dictionary")
+			overrides = nil
+		end
+
+		-- Loop over keys in the default table.
+		for k, dv in pairs(defaults) do
+			-- Note: luals requires an extra nil-check on overrides for some reason.
+			local uv = (overrides == true or overrides == nil) and dv or overrides and overrides[k]
+			-- Note: uv can be explicit false (to disable highlight) at this point.
+			if uv then
+				-- Validate and merge to get the vim.api.keyset.highlight to use.
+				local cfg, fallback, err = parse_highlight_entry(
+					uv, dv, normal, visual, replace_defaults)
+				-- Note: If cfg is explicit false, just skip.
+				if cfg or cfg == nil then
+					if cfg == nil then
+						-- Warn and use fallback.
+						Util.error(string.format(
+							"Ignoring invalid user-provided highlight for %s"
+							.. ": %s%s", k, vim.inspect(uv),
+							err and ": " .. err or ""))
+					end
+					assert(cfg or fallback, "Internal error: Fallback highlight for " .. k .. " is nil")
+					vim.api.nvim_set_hl(0, k, cfg or fallback or {})
+				end
+			end
+		end
+	end
 end
 
 function M.setup_augroups()
@@ -99,7 +331,12 @@ function M.setup_augroups()
 	})
 end
 
-function M.setup()
+---@param opt table?
+function M.setup(opt)
+	if opt then
+		-- If user provided an option table, persist it; otherwise, stick with defaults.
+		Config:setup(opt)
+	end
 	M.setup_keymaps()
 	M.setup_user_commands()
 	M.setup_augroups()

--- a/lua/nvim-treeclimber/config.lua
+++ b/lua/nvim-treeclimber/config.lua
@@ -1,0 +1,183 @@
+-- This module manages the treeclimber options with the aid of a treeclimber.Opt, which manages the
+-- actual option tables (user and default) and supports queries on nested keys.
+-- Design Note: The treeclimber-specific logic and data are intentionally kept separate from the Opt
+-- manager, which should be comletely generic.
+
+---@class treeclimber.Config
+---@field private opt? treeclimber.Opt
+local Config = {}
+
+-- The Config instance is a singleton, which holds a single Opt at a time.
+local Opt = require"nvim-treeclimber.opt"
+
+
+-- The default option table
+local defaults = {
+	ui = {
+		-- ** Keymaps **
+		---@alias modestr "n"|"v"|"x"|"o"|"s"|"i"|"!"|""
+		---@alias lhs string                # Used as <lhs> in call to `vim.keymap.set`
+		---@alias treeclimber.KeymapSingle
+		---| [(modestr|modestr[]), lhs]     # override the default <lhs> and/or modes
+		---@alias treeclimber.KeymapEntry
+		---| boolean                        # true to accept default, false to disable
+		---| nil                            # accept default (same as omitting command name from table)
+		---| lhs                            # override the default <lhs> in default mode(s)
+		---| treeclimber.KeymapSingle       # override the default <lhs> and/or modes
+		---| treeclimber.KeymapSingle[]     # idem, but allows multiple, mode-specific <lhs>'s
+		-- All entries in the default option table must be of this type.
+		-- TODO: Consider changing the defaults from <M-...> to <A-...>.
+		---@alias treeclimber.KeymapEntryDefCanon
+		---| false
+		---| treeclimber.KeymapSingle
+		---| treeclimber.KeymapSingle[]
+		-- All KeymapEntry's are converted to this by successful validation.
+		---@alias treeclimber.KeymapEntryCanon
+		---| false
+		---| treeclimber.KeymapSingle[]
+		---@type table<string, treeclimber.KeymapEntryDefCanon>
+		keys = {
+			show_control_flow = { "n", "<leader>k"},
+			select_current_node = {
+				-- Note: In normal mode, select_current_node and select_expand are
+				-- pretty much equivalent, but the former more accurately reflects
+				-- the nature of the operation.
+				{"n", "<M-k>"},
+				{{ "x", "o" }, "i."}
+			},
+			select_first_sibling = {{ "n", "x", "o" }, "<M-[>"},
+			select_last_sibling = {{ "n", "x", "o" }, "<M-]>"},
+			select_top_level = {{ "n", "x", "o" }, "<M-g>"},
+			select_forward = {{ "n", "x", "o" }, "<M-l>"},
+			select_backward = {{ "n", "x", "o" }, "<M-h>"},
+			select_forward_end = {{ "n", "x", "o" }, "<M-e>"},
+			select_grow_forward = {{ "n", "x", "o" }, "<M-L>"},
+			select_grow_backward = {{ "n", "x", "o" }, "<M-H>"},
+			select_expand = {
+				{{"x", "o"}, "a."},
+				{{"x", "o"}, "<M-k>"}
+			},
+			select_shrink = {{ "n", "x", "o" }, "<M-j>"},
+		},
+		-- ** User Commands **
+		-- Each entry of the 'cmds table configures the user command for a single treeclimber function.
+		---@alias treeclimber.UserCommandEntry
+		---| string   # user command name to create for this operation
+		---| boolean  # true to enable the default command, false to disable
+		-- The default entry is like UserCommandEntry except that true is disallowed, since the
+		-- entry must define a default command name.
+		---@alias treeclimber.UserCommandEntryCanon string|false
+		---@type {[string]: treeclimber.UserCommandEntryCanon}
+		cmds = {
+			diff_this = "TCDiffThis",
+			highlight_external_definitions = "TCHighlightExternalDefinitions",
+			show_control_flow = "TCShowControlFlow",
+		},
+	},
+	display = {
+		regions = {
+			-- ** Highlights **
+			---@alias treeclimber.HighlightCallback
+			---| fun(o: {normal: HSLUVHighlight, visual: HSLUVHighlight}) : vim.api.keyset.highlight
+			---@alias treeclimber.HighlightEntry
+			---| vim.api.keyset.highlight       # passed to `nvim_set_hl()`
+			---| treeclimber.HighlightCallback  # must return a `vim.api.keyset.highlight`
+			---| boolean                        # true for default highlights, false to disable group
+			---| nil                            # default highlights
+			-- Default canonical: either canonical or will expand to canonical.
+			-- Note: User option table may contain the less restrictive HighlightEntry,
+			-- but default option table should contain only HighlightEntryDefCanon.
+			---@alias treeclimber.HighlightEntryDefCanon
+			---| fun(o: {normal: HSLUVHighlight, visual: HSLUVHighlight}) : vim.api.keyset.highlight
+			---| vim.api.keyset.highlight
+			---| false
+			-- All HighlightEntry's converted to this by successful validation.
+			---@alias treeclimber.HighlightEntryCanon
+			---| vim.api.keyset.highlight
+			---| false
+			---@type table<string, treeclimber.HighlightEntryDefCanon>
+			highlights = {
+				-- Note: Overriding bg color of the visual selection doesn't work very well.
+				Selection = function(o) return { bg = o.visual.bg.hex } end,
+				SiblingStart = false,
+				Sibling = function(o) return { bg = o.visual.bg.mix(o.normal.bg, 50).hex } end,
+				Parent = function(o) return { bg = o.visual.bg.mix(o.normal.bg, 80).hex } end,
+				ParentStart = false,
+			},
+			-- `true` to cause attributes like bold and italic to "bleed through" from Parent
+			-- to Siblings.
+			inherit_attrs = true,
+			-- `true` to replace default 'highlights' with user overrides, false or nil to merge
+			replace_defaults = false,
+		},
+	},
+	traversal = {
+	},
+}
+
+-- Define some helpers.
+-- Return true iff input string is a mode string that could be used in a call to vim.keymap.set().
+function Config.is_mode(x)
+	return type(x) == "string" and x:match("^[nvxosi!]?$")
+end
+
+-- Return true iff input is an array of mode strings that could be used in a call to vim.keymap.set().
+function Config.is_mode_array(x)
+	return vim.islist(x) and vim.iter(x):all(function(x_) return Config.is_mode(x_) end)
+end
+
+-- Return true if input is of type treeclimber.KeymapSingle
+-- TODO: Consider adding an is_loose_keymap_entry function or somesuch, which doesn't validate,
+-- modes.
+-- Rationale: Could be used to improve error diagnostics.
+function Config.is_keymap_single(x)
+	return vim.islist(x) and #x == 2 and (Config.is_mode(x[1]) or Config.is_mode_array(x[1]))
+		and type(x[2]) == "string"
+end
+
+-- Return true if input is an array of treeclimber.KeymapSingle
+function Config.is_keymap_entry_array(x)
+	return vim.islist(x) and vim.iter(x):all(function (x_) return Config.is_keymap_single(x_) end)
+end
+
+-- Create a new Config object representing the default option table.
+-- Note: The first call to require('treeclimber.config') constructs a singleton Config object with
+-- an Opt managing pure defaults (since user could not have called setup() at that point). If a
+-- subsequent user call to setup() provides an option table override, we'll construct a new Opt
+-- encapsulating it; otherwise, we'll just keep the existing one.
+-- Rationale: This approach ensures things will work even if user skips call to setup() and calls
+-- (eg) setup_keymaps() manually.
+function Config:new()
+	local obj = {
+		-- Start with a default Opt, which may be overridden later with setup().
+		opt = Opt:new(defaults)
+	}
+	self.__index = self
+	return setmetatable(obj, self)
+end
+
+-- Note: Config:new() instantiates an Opt representing default configuration. That instance is
+-- perfectly capable of being used by Treeclimber if this function is never called (or if it's
+-- called with no option table).
+---@param opt? table
+function Config:setup(opt)
+	if opt then
+		self.opt = Opt:new(defaults, opt)
+	end
+end
+
+-- Get default option value for fully-qualified name.
+---@param fqn string[]|string
+function Config:get_default(fqn)
+	return self.opt:get(fqn, {want_default = true})
+end
+
+---@param fqn string[]|string
+function Config:get(fqn)
+	return self.opt:get(fqn)
+end
+
+-- Create and return singleton Config for treeclimber.
+-- Note: The default Opt it contains will be replaced if the setup() method is subsequently called
+-- with a user override.
+return Config:new()

--- a/lua/nvim-treeclimber/hi.lua
+++ b/lua/nvim-treeclimber/hi.lua
@@ -49,6 +49,10 @@ end
 
 M.HSLUVHighlight = {}
 
+-- Argument to the 'highlights' callback
+---@alias HSLUVHighlights
+---| {normal: HSLUVHighlight, visual: HSLUVHighlight}
+
 ---@param hl Highlight
 ---@return HSLUVHighlight
 function M.HSLUVHighlight:new(hl)

--- a/lua/nvim-treeclimber/opt.lua
+++ b/lua/nvim-treeclimber/opt.lua
@@ -1,0 +1,147 @@
+-- This module may be used to manage and query a hierarchical tree of options.
+-- The constructor takes a default option table and, optionally, a sparse table of overrides
+-- (typically a user option table). Query methods accept dot-separated name strings corresponding to
+-- nested keys, and return the corresponding values, with configurable fallback to defaults, error
+-- handling, table repair, etc.
+
+---@class treeclimber.Opt
+---@field private defaults table<string,any>
+---@field private current? table<string,any> # User option table (if provided)
+local Opt = {}
+
+local Util = require('nvim-treeclimber.util')
+
+---Parse and validate a fully-qualified option name, specified in string or table form, returning
+---the table form.
+---Note: Because this function is for internal use only, all option names are expected to be valid,
+---and we simply assert on validity.
+---@package
+---@param fqn string|string[] # Option name as either a dot-separated string or a table of name components
+---@return string[]           # Table of option name components
+function Opt:parse_fqn(fqn)
+	if type(fqn) == "string" then
+		fqn = vim.split(fqn, "[.]")
+	end
+	-- Verify that name components all look like normal keys.
+	assert(vim.iter(fqn):all(function(x) return x:match("[%w_]+") end),
+		"Bad fully-qualified option name: " .. vim.inspect(fqn))
+	return fqn
+end
+
+---@package
+---@param opt? table Table to override defaults
+function Opt:merge_current(opt)
+	-- TODO: Consider skipping the merge if opt is nil.
+	self.current = vim.tbl_deep_extend('force', self.defaults, opt or {})
+end
+
+---@param defaults table
+---@param opt? table
+function Opt:new(defaults, opt)
+	-- Note: current may be nil.
+	local obj = { defaults = defaults }
+	self.__index = self
+	setmetatable(obj, {__index = self})
+	-- Defer override of current until we have opt.
+	-- Rationale: There's no point in merging an empty table.
+	if opt then
+		obj:merge_current(opt)
+	end
+	return obj
+end
+
+-- TODO: Perhaps rename to set()
+---@param fqn string|string[]
+---@param value any
+function Opt:__newindex(fqn, value)
+	local keyarr = self:parse_fqn(fqn)
+	if not keyarr or #keyarr == 0 then
+		-- Shouldn't happen, but nothing to do.
+		return
+	end
+	-- Make sure we have an option table to modify.
+	if not self.current then
+		self:merge_current()
+	end
+	-- Ensure a path exists from the option table root to the descendant node at which we're
+	-- about to add a leaf, creating intervening nodes as necessary.
+	local last = vim.iter(keyarr)
+		:take(#keyarr - 1)
+		:fold(self.current, function (acc, k)
+			if acc[k] == nil then
+				acc[k] = {}
+			end
+			return acc[k]
+		end)
+	-- Add the leaf.
+	last[keyarr[#keyarr]] = value
+end
+
+
+-- Get value (either overridden or default) corresponding to the fully-qualified name <fqn>.
+-- If `current` is nil, we're managing pure (non-overridden) defaults, which means failure to find
+-- the key implies internal error (bad default option table). If a user override has been specified,
+-- it will have been merged with the default option table; thus, the <fqn> should be found unless
+-- an invalid user option table has broken the merge: e.g.,
+-- A user table of { foo = 42 } would prevent "foo.bar" from being found, even though it exists in
+-- the default table. The optional `QueryOpt` object may be used to customize lookup behavior (e.g.,
+-- handling of missing keys).
+---@class treeclimber.opt.QueryOpt
+---@field notify? "warning"|"error"|"exception"|false  # how to handle missing key, false to disable notification
+---@field want_default? boolean           # true to ignore user override table
+---@field repair? boolean                 # true to repair missing key from defaults (to
+---                                       # prevent repeat warnings)
+---@field fallback? boolean               # true to fallback to default
+---@param fqn string|string[]             # Fully-qualified option name string, either as array of
+---                                       # components or dot-separated string
+---@param default? any
+---@return any                            # the requested option value (possibly a fallback)
+function Opt:get(fqn, cfg, default)
+	-- Merge any caller-specified options with defaults.
+	cfg = vim.tbl_deep_extend("force",
+		{notify = "error", want_default = false, repair = true, fallback = true}, cfg or {})
+	-- TODO: Consider validating the booleans, though only internal error could result in
+	-- invalid format.
+	assert(not cfg.notify or vim.list_contains({"warning", "error", "assert"}, cfg.notify),
+		"Invalid value provided for missing.notify: " .. vim.inspect(cfg.notify))
+	-- Subsequent logic needs an options table, either user's current override (if one exists
+	-- and defaults not explicitly requested) or the defaults
+	local opt = not cfg.want_default and self.current or self.defaults
+	-- Input fqn can be in either of two forms: make sure we have it in valid array form.
+	local keyarr = self:parse_fqn(fqn)
+	-- Validate that name components all look like normal keys.
+	assert(vim.iter(keyarr):all(function(x) return x:match("[%w_]+") end),
+		"Bad fully-qualified option name: " .. fqn)
+	local v = vim.tbl_get(opt, unpack(keyarr))
+	if opt.notify == "assert" then
+		assert(v ~= nil, "Requested option not found: %s", fqn)
+	end
+	if v == nil then
+		-- Option not found
+		-- This should never happen if user hasn't overridden config.
+		assert(opt ~= self.defaults, "Internal error: missing default option key: " .. fqn)
+		-- Invalid user override must have clobbered something.
+		if opt.notify then
+			Util.notify(opt.notify, "Requested option not defined: %s", fqn)
+		end
+		-- Has caller supplied a default? If so, return it, without regard to missing.fallback.
+		local dvalue
+		if default ~= nil then
+			dvalue = default
+		elseif opt.fallback then
+			-- Return plugin-defined default (which should definitely exist).
+			dvalue = vim.tbl_get(self.defaults, unpack(keyarr))
+			assert(dvalue ~= nil, "Internal error: requested option has no fallback: " .. fqn)
+		end
+		if opt.repair and dvalue ~= nil then
+			-- We have a fallback and repair is enabled.
+			-- Assumption: An earlier assert() ensures we arrive here only when user has
+			-- overridden defaults.
+			self[keyarr] = dvalue
+		end
+		v = dvalue
+	end
+	return v
+end
+
+return Opt

--- a/lua/nvim-treeclimber/util.lua
+++ b/lua/nvim-treeclimber/util.lua
@@ -1,0 +1,27 @@
+---@class treeclimber.Util
+local Util = {}
+
+---@param how "warning"|"error"|"exception"
+---@param str string the formatting string
+---@param ... any
+function Util.notify(how, str, ...)
+	str = string.format("Treeclimber: " .. str, ...)
+	if how == "exception" then
+		error(str)
+	else
+		-- Design Decision: Always set 'err' flag (even if warning) to ensure notification is seen.
+		vim.api.nvim_echo({{str , how == "warning" and "WarningMsg" or "ErrorMsg"}},
+			true, {err = true})
+	end
+end
+
+function Util.warn(str, ...)
+	Util.notify("warning", str, ...)
+end
+
+function Util.error(str, ...)
+	Util.notify("error", str, ...)
+end
+
+
+return Util


### PR DESCRIPTION
# Overview

Adds a configuration mechanism intended to simplify installation, loading and configuration of the treeclimber plugin, and uses it to provide user customization of the following:

* Keymaps
* User Commands
* Region Decoration Highlights

Also, renames 2 misleading api function names in a backwards-compatible way.  
**Rationale:** The names `select_siblings_forward` and `select_siblings_backward` do not match their description, and thus, could be a source of confusion to new users. Aliases have been introduced to ensure the old functions can still serve as the target of mappings (though only the new names can be used as keys in the new option table).


# Motivation

Currently, a user who simply wishes to override one of the default keymaps must reimplement `setup_keymaps()` and explicitly call `setup_user_commands()` and `setup_augroups()`. This approach exposes too much implementation detail to the user and increases the probability that a prospective user unfamiliar with the Neovim plugin system will simply give up. Moreover, although a considerable amount of work seems to have gone into the modules supporting *HSLUV* colors, the lack of a configuration mechanism prevents the user from benefiting from it. And because all regions other than the primary selection region use the same bg color, there is little benefit to the support of separate sibling and parent regions.

When I first started using treeclimber, I was occasionally surprised by the parent-child relationships encountered while navigating the AST: e.g., the fact that a function's parameter list is a sibling of its body felt unintuitive. Having the region decorations provide clear disambiguation between parent and child, and even between adjacent children, can reduce confusion for the new treeclimber user (or a treeclimber user working with a new language).

# Installation/Loading

With a plugin manager like Lazy, a default installation/load is still as simple as adding a file like this under ~/.config/nvim/lua/plugins:

```
return {
  "dkendal/nvim-treeclimber",
}
```

Overriding the defaults is almost as easy: e.g., to customize the keymaps for `select_forward/backward` and add bold-italic to the decoration for the currently-selected node...

```
return {
  "dkendal/nvim-treeclimber",
  opts = {
    ui = {
      keys = {
        select_forward = "<A-w>",
        select_backward = "<A-b>",
      },
    },
    display = {
      regions = {
        highlights = {
          Selection = {bold = true, italic = true},
        },
      },
    },
  }
}
```

Existing users should not be affected by these changes, as it's still possible to call the `setup()` function explicitly, with or without an option table. As before, omitting the option table in the call to `setup()` requests defaults.

# Option Table Support

Module `opt` provides a generic interface to a hierarchical option table, which encapsulates a table of defaults and (optionally) a table of user overrides. The treeclimber defaults are defined in the singleton module `config`, which creates and manages an `opt` instance capable of serving requests for specific option keys. The option table is organized in sub-trees: e.g., `ui` for keymaps and user commands, `display` for highlights, etc. The default option table is documented with comments in the README.md. The `config` module provides `get()` and `get_default()` methods, which accept option keys as a string of dot-separated components: e.g., `ui.keys` and `display.regions.highlights`. The `opt` module does more than simply merge user overrides into the default table. The reason is that users occasionally provide malformed option tables, and when they do, plugins based on the idiomatic vim.api.tbl_deep_extend() approach tend to spew errors and die, leaving the plugin in an indeterminate state. The approach in this PR, built around the `opt` module, is to fall back to sane defaults with a warning.

# Keymap Customization

The option table's nested key `ui.keys` may be used to customize (without completely replacing) the default keymaps.
This table contains a separate key for each treeclimber api function. The key value format is flexible enough to acommodate the most complex scenarios, while keeping the simple (and common) use case simple: e.g., to change the default keybinding for `select_forward` to `<A-w>`...

```
  select_forward = "<A-w>",
```

To create different maps in visual/select and normal/operator-pending modes...

```
  select_forward = { {"x", ">"}, {{"n", "o"}, "<A-w>"} },
```

To disable a map altogether...
```
  select_forward = false,
```

# User Command Customization

The option table's nested key `ui.cmds` may be used to customize the default user commands, changing the command name or disabling the command altogether.

# Region Highlighting Customization

The current implementation suffers from the following limitations pertaining to region decoration:

* All regions other than the current selection use the same bg color, making it impossible to distinguish between parent and sibling groups (and there's no way for the user to change this).
* A bug in `apply_decoration` causes all adjacent siblings to combine into a single visual group; thus, even if the user manually altered the bg colors, the desired differentiation between groups would not be achieved.
* Highlight attributes such as bold and italic are not supported. When used properly, such attributes may be used to make regions stand out significantly better than do bg colors alone.

The `display.regions.highlights` key allows the user to tailor the highlighting of the various groups and/or disable unwanted groups altogether. The format of the key is flexible and fully documented in the README. The simplest key values are `vim.api.keyset.highlight` objects containing fg/bg colors and/or attributes like 'bold' and 'italic'. But they can also be callback functions that return such objects. Callbacks permit use of *HSLUVHighlight* objects that may not be available until colorscheme load, which is most likely *after* the user option table has been defined.

There's also an option that determines whether attributes defined for the parent groups "bleed through" to the children (siblings). Because of the way Neovim handls extmark `hl_group`s, attributes set on the Parent also appear in the contained Siblings. If bleed-through is not desired, it's necessary to break the Parent into discontiguous regions. (An optimization would permit use of a single Parent if it's determined that none of the `hl_group`s use such attributes, but the optimization has not been implemented.) There's also an option that determines whether a user-provided highlight *combines with* the parent or *replaces* it. This affects only attributes like bold and italic, since Neovim doesn't combine the bg colors.

The default parent and sibling bg colors are now visuallly distinct, and the reworked `apply_decoration()` intentionally allows the parent highlight to show through in the space between named children, making it easier to tell exactly where one sibling ends and another begins.
